### PR TITLE
Fixed laterals.md

### DIFF
--- a/cldf/docs/laterals.md
+++ b/cldf/docs/laterals.md
@@ -1,4 +1,6 @@
-Feature set adapted and extended from [Maddieson 2013](Source#cldf:maddieson2013wals8).
+# [](ParameterTable?__template__=property.md&name=name#cldf:Lat-01)
+
+Feature set adapted and extended from [Maddieson 2013](Source?ref&with_internal_ref_link#cldf:maddieson2013wals8).
 
 **Authors**: [David Inman](../contributors/DI), [Kellen Parker Van Dam](../contributors/KPVD)
 
@@ -28,16 +30,16 @@ Voiced alveolar (lateral) approximant /l/, and allophonic \[l\] when it alternat
 The survey does not distinguish between two very close places of articulation, namely alveolar and apico-dental, as they rarely stand in phonemic opposition. We also exclude phonemes that occur solely in recent loans.
 
 ## Why?
-The presence or absence of laterals and lateral obstruents is claimed to cluster in geographic regions. [Maddieson 2013](Source#cldf:maddieson2013wals8) notes a cluster of /l/-less languages in northern South America (and New Guinea), and the presence of lateral obstruents in northern and western North America (as well as in the Caucasus and around Lake Chad).
+The presence or absence of laterals and lateral obstruents is claimed to cluster in geographic regions. [Maddieson 2013](Source?ref&with_internal_ref_link#cldf:maddieson2013wals8) notes a cluster of /l/-less languages in northern South America (and New Guinea), and the presence of lateral obstruents in northern and western North America (as well as in the Caucasus and around Lake Chad).
 
-[Maddieson 2013](Source#cldf:maddieson2013wals8) focuses on obstruent vs sonorant laterals. However, the precise type of obstruent is claimed as distinctive in other work, namely /tɬ’/ in the Pacific Northwest, even when a language lacks /tɬ/ ([Sherzer 1976](Source#cldf:sherzer1976northamerica); [Thompson and Kinkade 1990](Source#cldf:thompsonkinkade1990pnw); [Beck 2000](Source#cldf:beck2000nwcoast)). The voiced lateral affricate /dɮ/ is not included in this survey, as [Maddieson 2013](Source#cldf:maddieson2013wals8) only finds one language (Tigak; Austronesian; Papua New Guinea) that has a voiced /dɮ/ without a corresponding voiceless /tɬ/.
+[Maddieson 2013](Source?ref&with_internal_ref_link#cldf:maddieson2013wals8) focuses on obstruent vs sonorant laterals. However, the precise type of obstruent is claimed as distinctive in other work, namely /tɬ’/ in the Pacific Northwest, even when a language lacks /tɬ/ ([Sherzer 1976](Source?ref&with_internal_ref_link#cldf:sherzer1976northamerica); [Thompson and Kinkade 1990](Source?ref&with_internal_ref_link#cldf:thompsonkinkade1990pnw); [Beck 2000](Source?ref&with_internal_ref_link#cldf:beck2000nwcoast)). The voiced lateral affricate /dɮ/ is not included in this survey, as [Maddieson 2013](Source?ref&with_internal_ref_link#cldf:maddieson2013wals8) only finds one language (Tigak; Austronesian; Papua New Guinea) that has a voiced /dɮ/ without a corresponding voiceless /tɬ/.
 
-/ɬ/ as a feature is common in North America in Maddieson’s survey, and has also been claimed to be prominent in the North American Southeast ([Haas 1969](Source#cldf:haas1969prehistory); [Campbell 1997](Source#cldf:campbell1997america)), and in the Southern Andean core ([Michael et al 2014: 33](Source#cldf:michaeletal2014andean)). It’s unclear whether these represent truly distinct areas, or if a high frequency of the /ɬ/ phoneme is part of a broader American west coast pattern.
+/ɬ/ as a feature is common in North America in Maddieson’s survey, and has also been claimed to be prominent in the North American Southeast ([Haas 1969](Source?ref&with_internal_ref_link#cldf:haas1969prehistory); [Campbell 1997](Source?ref&with_internal_ref_link#cldf:campbell1997america)), and in the Southern Andean core ([Michael et al 2014: 33](Source?ref&with_internal_ref_link#cldf:michaeletal2014andean)). It’s unclear whether these represent truly distinct areas, or if a high frequency of the /ɬ/ phoneme is part of a broader American west coast pattern.
 
-/ʎ/ stands among the distinctive core phonological features for the Southern Andean core ([Michael et al 2014](Source#cldf:michaeletal2014andean)).
+/ʎ/ stands among the distinctive core phonological features for the Southern Andean core ([Michael et al 2014](Source?ref&with_internal_ref_link#cldf:michaeletal2014andean)).
 
 ## How?
-Some of the data for this feature set were obtained directly from the PHOIBLE database version 2.0 ([PHOIBLE](Source#cldf:phoible, accessed January 27, 2020). A custom R script was written to process it. For Lat.01, which considers the allophones of the segment [l], all languages in PHOIBLE that had an inventory without an /l/ phoneme or \[l\] allophone were coded as <no>, and the remainder that did have a lateral liquid present somewhere were marked to be reviewed by hand. The presence or absence of /ɬ/, /tɬ/, /tɬ’/, and /ʎ/ (Lat.03, Lat.04, Lat.05, Lat.06) were extracted and encoded by the binary presence or absence of the relevant segment. Afterwards, 19 extracted languages were checked against grammars for accuracy, which yielded an acceptable error rate. Other discrepancies found in the data or cases where more recent sources have become available were corrected opportunistically while coding for other features. Such corrections are marked by “contra-PHOIBLE” in the remark field of the database.
+Some of the data for this feature set were obtained directly from the PHOIBLE database version 2.0 ([PHOIBLE](Source?ref&with_internal_ref_link#cldf:phoible), accessed January 27, 2020). A custom R script was written to process it. For Lat.01, which considers the allophones of the segment [l], all languages in PHOIBLE that had an inventory without an /l/ phoneme or \[l\] allophone were coded as <no>, and the remainder that did have a lateral liquid present somewhere were marked to be reviewed by hand. The presence or absence of /ɬ/, /tɬ/, /tɬ’/, and /ʎ/ (Lat.03, Lat.04, Lat.05, Lat.06) were extracted and encoded by the binary presence or absence of the relevant segment. Afterwards, 19 extracted languages were checked against grammars for accuracy, which yielded an acceptable error rate. Other discrepancies found in the data or cases where more recent sources have become available were corrected opportunistically while coding for other features. Such corrections are marked by “contra-PHOIBLE” in the remark field of the database.
 
 The remaining data were coded by hand from available phonological and phonetic descriptions.
 
@@ -59,32 +61,32 @@ The final state <no> includes all languages that have no /l/ phoneme at all, and
 In the case where the language only has a lateral flap, as is the case in Cavineña [cavi1250] (Pano-Tacanan; Bolivia), Western Keres [west2632] (Keresan; United States), and Tohono O’odham [toho1245] (Uto-Aztecan; Mexico, United States), this feature was coded as a ?. This is because it could pattern areally both as a non-lateral (non-continuous, as a flap), or as a lateral (since it is laterally articulated).
 
 #### laterals or glides: Lillooet \[lill1248\] (Salishan; Canada)
-St’at’imcets or Lillooet contains a phonemic /l/ which does not appear to alternate with other phonemes, as in words like lóləm’ ‘jealous in love’ ([Eijk 1997: 2, 11](Source#cldf:eijk1997lillooet)
+St’at’imcets or Lillooet contains a phonemic /l/ which does not appear to alternate with other phonemes, as in words like lóləm’ ‘jealous in love’ ([Eijk 1997: 2, 11](Source?ref&with_internal_ref_link#cldf:eijk1997lillooet)
 
 #### laterals or glides: Cherokee \[cher1273\] (Iroquoian; United States)
-Cherokee contains a phonemic /l/, as in words like aaliíyo ‘sock’ ([Montgomery-Anderson 2008](Source#cldf:montgomeryanderson2008cherokee): 33, 41).
+Cherokee contains a phonemic /l/, as in words like aaliíyo ‘sock’ ([Montgomery-Anderson 2008](Source?ref&with_internal_ref_link#cldf:montgomery-anderson2008cherokee): 33, 41).
 
 #### n or d: Ese Ejja \[esee1248\] (Pano-Tacanan; Peru, Bolivia)
-Ese Ejja has a \[d\]/\[n\]/\[l\] phonemic alternation [Vuillermet 2012: 165](Source#cldf:vuillermet2012eseejja). \[l\] is only heard in the speech of older people, with the other allophones being more common in other speakers (Vuillermet, p.c.).
+Ese Ejja has a \[d\]/\[n\]/\[l\] phonemic alternation [Vuillermet 2012: 165](Source?ref&with_internal_ref_link#cldf:vuillermet2012eseejja). \[l\] is only heard in the speech of older people, with the other allophones being more common in other speakers (Vuillermet, p.c.).
 
 #### rhotic: Cocama-Cocamilla \[coca1259\] (Tupian; Peru)
-Cocama-Cocamilla has a phoneme that alternates between \[l\] and \[ɾ\] with completely free variation [Vallejos 2016: 47](Source#cldf:vallejos2016kukama). According to Vallejos, it is possible that this developed from an older system that had just /l/.
+Cocama-Cocamilla has a phoneme that alternates between \[l\] and \[ɾ\] with completely free variation [Vallejos 2016: 47](Source?ref&with_internal_ref_link#cldf:vallejos2016kukama). According to Vallejos, it is possible that this developed from an older system that had just /l/.
 
 #### no: Nuuchahnulth \[nuuc1236\] (Wakashan; Canada)
-Nuuchahnulth contains no \[l\] sound, despite having /ɬ/, /t͡ɬ/, and /t͡ɬ’/ [Nakayama 2001: 7](Source#cldf:nakayama2001nuuchahnulth). This is even visible in loanwords, where a borrowed /l/ becomes /n/, as in taana, ultimately from English ‘dollar’ (Inman, p.c.).
+Nuuchahnulth contains no \[l\] sound, despite having /ɬ/, /t͡ɬ/, and /t͡ɬ’/ [Nakayama 2001: 7](Source?ref&with_internal_ref_link#cldf:nakayama2001nuuchahnulth). This is even visible in loanwords, where a borrowed /l/ becomes /n/, as in taana, ultimately from English ‘dollar’ (Inman, p.c.).
 
 #### ?: Western Keres \[west2632\] (Keresan; United States)
-Western Keres contains a lateral flap [Valiquette 1990: 14](Source#cldf:valiquette1990keres), described as “something of a combination of a Spanish flapped /r/ and a lateral.”
+Western Keres contains a lateral flap [Valiquette 1990: 14](Source?ref&with_internal_ref_link#cldf:valiquette1990keres), described as “something of a combination of a Spanish flapped /r/ and a lateral.”
 
 #### no: Nanti \[nant1250\] (Arawakan; Peru)
-Nanti only has a flap /ɾ/ as a liquid, and no /l/ [Michael 1008: 221](Source#cldf:michael2008nanti).
+Nanti only has a flap /ɾ/ as a liquid, and no /l/ [Michael 1008: 221](Source?ref&with_internal_ref_link#cldf:michael2008nanti).
 
 ### Lat.02 Does the language have a phonemic voiceless lateral approximant /l̥/?
   **{ yes | no }**
 
 /l̥/ signifies a voiceless non-fricative approximant. This differs from Lat.03 /ɬ/, which is a fricative non-approximant lateral.
 
-This feature was actually added after coding was completed for the other features because we discovered that a few languages had a /l̥/, which seemed to behave in a phonologically similar way to /ɬ/, so we wanted to track it as a potentially informative lateral. We first reviewed the PHOIBLE database to check the cooccurrences of /l̥/ with other lateral segments. Of 2,186 languages in the database, only one, Wakhi, was claimed to have a voiceless /l̥/ without /l/, citing [Paxalina 1975](Source#cldf:paxalina1975wakhi). However, another grammar ([Lorimer 1958](Source#cldf:lorimer1958wakhi)) notes an /l/ with, potentially, an allophone [l̥]: “I occasionally recorded an l which I marked as abnormal. I think that in most cases it may have been a voiceless l” ([Lorimer 1958: 53-54](Source#cldf:lorimer1958wakhi)). Because this state (/l̥/ without /l/) seems to be vanishingly rare if not impossible, we automatically coded a <no> to Lat.02 for all languages that lack an /l/ or an \[l]\ (<no> to Lat.01), with the remark “auto”.
+This feature was actually added after coding was completed for the other features because we discovered that a few languages had a /l̥/, which seemed to behave in a phonologically similar way to /ɬ/, so we wanted to track it as a potentially informative lateral. We first reviewed the PHOIBLE database to check the cooccurrences of /l̥/ with other lateral segments. Of 2,186 languages in the database, only one, Wakhi, was claimed to have a voiceless /l̥/ without /l/, citing [Paxalina 1975](Source?ref&with_internal_ref_link#cldf:paxalina1975wakhi). However, another grammar ([Lorimer 1958](Source?ref&with_internal_ref_link#cldf:lorimer1958wakhi)) notes an /l/ with, potentially, an allophone [l̥]: “I occasionally recorded an l which I marked as abnormal. I think that in most cases it may have been a voiceless l” ([Lorimer 1958: 53-54](Source?ref&with_internal_ref_link#cldf:lorimer1958wakhi)). Because this state (/l̥/ without /l/) seems to be vanishingly rare if not impossible, we automatically coded a <no> to Lat.02 for all languages that lack an /l/ or an \[l]\ (<no> to Lat.01), with the remark “auto”.
 
 We also noted that there are zero inventories in PHOIBLE that showed both a phonemic /l̥/ and /ɬ/. Therefore, we again automatically coded the state <no> to Lat.02 if the language possesses a /ɬ/ (i.e., <yes> to Lat.03), with the remark "auto". This reduced the number of languages coded by hand after the rest of the features set had been completed.
 
@@ -97,7 +99,7 @@ A phoneme that has \[ɬ\] as a prominent allophone (perhaps alternating with \[�
 Nuuchahnulth has a phonemic /ɬ/ as in the first sound in łiw̓aḥak ‘cloudy’ and the last sound in ƛuł ‘good’ (Inman, personal knowledge).
 
 #### no: Pipil \[pipi1250\] (Uto-Aztecan; El Salvador, Honduras)
-Pipil has an \[ɬ\] alternating  with the main allophone \[l\]. Historically \[ɬ\] was a word final variant of /l/ but it is now present in more contexts. Still, \[l\] is the main realization and thus considered the phoneme ([Campbell 1985](Source#cldf:campbell1985pipil)).
+Pipil has an \[ɬ\] alternating  with the main allophone \[l\]. Historically \[ɬ\] was a word final variant of /l/ but it is now present in more contexts. Still, \[l\] is the main realization and thus considered the phoneme ([Campbell 1985](Source?ref&with_internal_ref_link#cldf:campbell1985pipil)).
 
 ### Lat.04 Does the language have a phonemic alveolar lateral affricate /tɬ/?
   **{ yes | no }**
@@ -106,14 +108,14 @@ Pipil has an \[ɬ\] alternating  with the main allophone \[l\]. Historically \[�
 Nuuchahnulth has a phonemic /t͡ɬ/ as in the first sound in ƛaʔuu ‘other’ and the last sound in haw̓iiqƛ ‘hungry’ (Inman, p.c.).
 
 #### yes: Cherokee \[cher1273\] (Iroquoian; United States)
-An underlying /t͡ɬ/ in Cherokee has shifted to \[ɬ\] in the Oklahoma variety. This is an ongoing change. Phonetically, the language appears to have merged this phoneme with /ɬ/, however according to [Montgomery-Anderson 2008](Source#cldf:montgomeryanderson2008cherokee),
+An underlying /t͡ɬ/ in Cherokee has shifted to \[ɬ\] in the Oklahoma variety. This is an ongoing change. Phonetically, the language appears to have merged this phoneme with /ɬ/, however according to [Montgomery-Anderson 2008](Source?ref&with_internal_ref_link#cldf:montgomery-anderson2008cherokee),
 
 \[the phonemes'\] separate identity as distinctive sounds is established through their behavior relative to vowel deletion and metathesis. (p.39)
 
 Therefore it is clear that underlyingly, Oklahoma Cherokee retains these as two separate phonemes despite cases showing an apparent phonetic merger.
 
 #### no: Hupa \[hupa1240\] (Athabaskan-Eyak-Tlingit; United States)
-Though Hupa has both an /l/ and a /ɬ/, it does not have a /t͡ɬ/ ([Golla 1970](Source#cldf:golla1970hupa)).
+Though Hupa has both an /l/ and a /ɬ/, it does not have a /t͡ɬ/ ([Golla 1970](Source?ref&with_internal_ref_link#cldf:golla1970hupa)).
 
 ### Lat.05 Does the language have a phonemic alveolar lateral ejective affricate /tɬ’/?
   **{ yes | no }**
@@ -122,7 +124,7 @@ Though Hupa has both an /l/ and a /ɬ/, it does not have a /t͡ɬ/ ([Golla 1970]
 Nuuchahnulth has a phonemic /t͡ɬ’/ as in the difference between ƛuł ‘good’ and ƛ̓ułšiƛ ‘touch, feel’ (Inman, p.c.).
 
 #### no: Cherokee \[cher1273\] (Iroquoian; United States)
-Cherokee has no ejective series and lacks /t͡ɬ’/ ([Montgomery-Anderson 2008](Source#cldf:montgomeryanderson2008cherokee): 33).
+Cherokee has no ejective series and lacks /t͡ɬ’/ ([Montgomery-Anderson 2008](Source?ref&with_internal_ref_link#cldf:montgomery-anderson2008cherokee): 33).
 
 ### Lat.06 Does the language have a phonemic palatal lateral approximant /ʎ/?
   **{ yes | no }**
@@ -132,12 +134,12 @@ NOTE: While the IPA symbol for the palatal lateral is \[ʎ\], this is not always
 There is an articulatory distinction between a lateral with a palatal off-glide (realized phonetically at the beginning of the following vowel) and a lateral with palatal articulation. However, we do not think this distinction will be significant areally: i.e., if a language has an alveolar lateral with an off-glide /lʲ/, and a language has a true palatal lateral /ʎ/, from an areal perspective, we think these phonemes are mutually reinforcing. There is also an analytical issue, as different linguists may approach the same set of facts with some coming to the analysis of an /lʲ/ phoneme and others of a /ʎ/. The same arguments can be extended to /ȴ/. For the purposes of this feature set, then, we consider all palatal or palatalized laterals to share the same state, <yes>. However, it is important that this sound be a unitary phoneme: i.e., treated by the phonology of the language as a single phoneme, and not the juxtaposition of /l/ + /j/.
 
 #### yes: Northern Yukaghir \[nort2745\] (Yukaghir; Russia)
-Northern Yukaghir has an palatalized lateral, Romanized as l’, which contrasts with a non-palatalized lateral, Romanized as l ([Schmalz 2013: 30](Source#cldf:schmalz2013yukaghir)).
+Northern Yukaghir has an palatalized lateral, Romanized as l’, which contrasts with a non-palatalized lateral, Romanized as l ([Schmalz 2013: 30](Source?ref&with_internal_ref_link#cldf:schmalz2013yukaghir)).
 
 #### no: Cherokee \[cher1273\] (Iroquoian; United States)
-Despite its other lateral phonemes, Cherokee lacks a palatal lateral ([Montgomery-Anderson 2008](Source#cldf:montgomeryanderson2008cherokee): 33).
+Despite its other lateral phonemes, Cherokee lacks a palatal lateral ([Montgomery-Anderson 2008](Source?ref&with_internal_ref_link#cldf:montgomery-anderson2008cherokee): 33).
 Derived features
-Derived features offer different views of the same data included in the base features. Often, this is done to group together some states of multi-state features, to capture specific similarities. In other cases, derived features are designed so that they are independent from other features used in the same computational analyses that assume feature independence, e.g. the Bayesian software sBayes, which detects areal signal ([Ranacher et al 2021](Source#cldf:ranacher2021sbayes)).
+Derived features offer different views of the same data included in the base features. Often, this is done to group together some states of multi-state features, to capture specific similarities. In other cases, derived features are designed so that they are independent from other features used in the same computational analyses that assume feature independence, e.g. the Bayesian software sBayes, which detects areal signal ([Ranacher et al 2021](Source?ref&with_internal_ref_link#ranacher2021sbayes)).
 
 ### Lat.01a Does the language have an allophonic \[l\]?
   **{ yes | no }**
@@ -217,46 +219,10 @@ NA 	if Lat.04a is <no>
 This derived feature conditions the presence of /tɬ’/ on the presence of any lateral affricate.
 
 ## Results
-Following the observations of [Maddieson 2013](Source#cldf:maddieson2013wals8), the Greater Amazon is overwhelmingly characterized by an absence of /l/ phonemes altogether (Lat.01). The presence of an /l～ɾ/ phoneme is most common in Papunesia and parts of Southern and Central America, however even in these regions it is a minority pattern. As expected, the Pacific Northwest of North America is characterized by /tɬ/ and /tɬ’/ phonemes (Lat.04, Lat.05), while the presence of /ɬ/ is somewhat more widespread, characterizing the Pacific Northwest, but also the North American Pueblos, the American Southeast, and the Gran Chaco. The presence of a phonemic voiceless /l̥/ (Lat.02) is extremely rare, without apparent areal patterns. The palatal lateral /ʎ/ (Lat.06) is characteristic of the west coast of South America and the northwest coast of Australia. Our sample is not dense enough to demonstrate it, but the Eurasian sample suggests that palatal lateral phonemes are also especially present in northern Eurasia.
+Following the observations of [Maddieson 2013](Source?ref&with_internal_ref_link#cldf:maddieson2013wals8), the Greater Amazon is overwhelmingly characterized by an absence of /l/ phonemes altogether (Lat.01). The presence of an /l～ɾ/ phoneme is most common in Papunesia and parts of Southern and Central America, however even in these regions it is a minority pattern. As expected, the Pacific Northwest of North America is characterized by /tɬ/ and /tɬ’/ phonemes (Lat.04, Lat.05), while the presence of /ɬ/ is somewhat more widespread, characterizing the Pacific Northwest, but also the North American Pueblos, the American Southeast, and the Gran Chaco. The presence of a phonemic voiceless /l̥/ (Lat.02) is extremely rare, without apparent areal patterns. The palatal lateral /ʎ/ (Lat.06) is characteristic of the west coast of South America and the northwest coast of Australia. Our sample is not dense enough to demonstrate it, but the Eurasian sample suggests that palatal lateral phonemes are also especially present in northern Eurasia.
 
 
 ## References
 
-[Beck 2000](Source#cldf:beck2000nwcoast)
-
-[Campbell 1985](Source#cldf:campbell1985pipil)
-
-[Campbell 1997](Source#cldf:campbell1997america)
-
-[van Eijk 1997](Source#cldf:eijk1997lillooet)
-
-[Golla 1970](Source#cldf:golla1970hupa)
-
-[Haas 1969](Source#cldf:haas1969prehistory)
-
-[Lorimer 1958](Source#cldf:lorimer1958wakhi)
-
-[Maddieson 2013](Source#cldf:maddieson2013wals8)
-
-[Michael 2008](Source#cldf:michael2008nanti)
-
-[Michael et al 2014](Source#cldf:michaeletal2014andean)
-
-[Montgomery-Anderson 2008](Source#cldf:montgomeryanderson2008cherokee)
-
-[Nakayama 2001](Source#cldf:nakayama2001nuuchahnulth)
-
-[Paxalina 1975](Source#cldf:paxalina1975wakhi)
-
-[Moran and McCloy 2019](Source#cldf:phoible)
-
-[Sherzer 1976](Source#cldf:sherzer1976northamerica)
-
-[Thompson and Kinkade 1990](Source#cldf:thompsonkinkade1990pnw)
-
-[Valiquette 1990](Source#cldf:valiquette1990keres)
-
-[Vallejos 2016](Source#cldf:vallejos2016kukama)
-
-[Vuillermet 2012](Source#cldf:vuillermet2012eseejja)
+[References](Source?cited_only#cldf:__all__)
 


### PR DESCRIPTION
The CLDF Markdown can now be rendered to standard markdown via
```shell
cldfbench cldfviz.text --text-file cldf/docs/laterals.md
```
(after cldfviz>=1.0.2 has been installed)